### PR TITLE
fix: PR bumped `openai` from 5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^15.5.2
         version: 15.5.2(@babel/core@7.28.4)(react-dom@19.1.1)(react@19.1.1)
       openai:
-        specifier: ^5.20.0
-        version: 5.20.0
+        specifier: ^6.9.1
+        version: 6.15.0
       pino:
         specifier: ^9.9.4
         version: 9.9.4
@@ -7626,6 +7626,19 @@ packages:
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+    dev: false
+
+  /openai@6.15.0:
+    resolution: {integrity: sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The PR bumped `openai` from 5.20.0 to 6.9.1 in `apps/web/package.json` but didn't regenerate `pnpm-lock.yaml`. CI runs with `--frozen-lockfile` which fails when the lockfile doesn't match package.json.

### What I fixed
Updated `pnpm-lock.yaml` to include the openai 6.x dependency (resolves to 6.15.0). This was a one-line change in package.json without the corresponding lockfile update - a common Dependabot issue.

**Commit:** `e30130a fix: update pnpm-lock.yaml for openai 6.x upgrade`

All checks now pass:
- ✅ `pnpm install --frozen-lockfile` 
- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test:run`

### The details
<details>
<summary>Full diagnosis</summary>

---

### Root Cause
The PR bumped `openai` from 5.20.0 to 6.9.1 in `apps/web/package.json` but didn't regenerate `pnpm-lock.yaml`. CI runs with `--frozen-lockfile` which fails when the lockfile doesn't match package.json.

### Fix
Updated `pnpm-lock.yaml` to include the openai 6.x dependency (resolves to 6.15.0). This was a one-line change in package.json without the corresponding lockfile update - a common Dependabot issue.

**Commit:** `e30130a fix: update pnpm-lock.yaml for openai 6.x upgrade`

All checks now pass:
- ✅ `pnpm install --frozen-lockfile` 
- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test:run`
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #286 in misty-step/brainrot*
