### PR TITLE
🛠️ Inquirer v13 is a breaking change - it removed the

### DIFF
--- a/apps/publisher/package.json
+++ b/apps/publisher/package.json
@@ -30,7 +30,7 @@
     "commander": "^14.0.1",
     "dotenv": "^17.2.2",
     "form-data": "^4.0.4",
-    "inquirer": "^13.0.1",
+    "@inquirer/prompts": "^7.0.0",
     "js-yaml": "^4.1.0",
     "ora": "^8.2.0",
     "p-retry": "^5.1.0",
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@types/form-data": "^2.5.2",
-    "@types/inquirer": "^9.0.7",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^24.3.1",
     "eslint": "^9.35.0",

--- a/apps/publisher/src/services/kdp.ts
+++ b/apps/publisher/src/services/kdp.ts
@@ -2,7 +2,7 @@ import { chromium, Browser, Page, BrowserContext } from "playwright";
 import path from "path";
 import fs from "fs/promises";
 import { Logger } from "../utils/logger.js";
-import inquirer from "inquirer";
+import { input } from "@inquirer/prompts";
 
 interface KdpConfig {
   email: string;
@@ -168,15 +168,11 @@ export class KdpService {
 
         // Handle OTP input
         if (await this.page.isVisible("input#auth-mfa-otpcode")) {
-          const { otp } = await inquirer.prompt([
-            {
-              type: "input",
-              name: "otp",
-              message: "Enter your 2FA code:",
-              validate: (input) =>
-                /^\d{6}$/.test(input) || "Please enter a valid 6-digit code",
-            },
-          ]);
+          const otp = await input({
+            message: "Enter your 2FA code:",
+            validate: (value) =>
+              /^\d{6}$/.test(value) || "Please enter a valid 6-digit code",
+          });
 
           await this.page.fill("input#auth-mfa-otpcode", otp);
           await this.page.click("input#auth-signin-button");
@@ -186,15 +182,11 @@ export class KdpService {
         if (await this.page.isVisible('text="Get OTP on SMS"')) {
           await this.page.click('text="Get OTP on SMS"');
 
-          const { smsCode } = await inquirer.prompt([
-            {
-              type: "input",
-              name: "smsCode",
-              message: "Enter the code sent to your phone:",
-              validate: (input) =>
-                /^\d{6}$/.test(input) || "Please enter a valid 6-digit code",
-            },
-          ]);
+          const smsCode = await input({
+            message: "Enter the code sent to your phone:",
+            validate: (value) =>
+              /^\d{6}$/.test(value) || "Please enter a valid 6-digit code",
+          });
 
           await this.page.fill('input[name="otpCode"]', smsCode);
           await this.page.click('input[type="submit"]');


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Inquirer v13 is a breaking change - it removed the legacy `inquirer.prompt()` API and now requires `@inquirer/prompts` package with individual prompt functions like `input()`.

### What I fixed
Edited 2 files:
1. **`apps/publisher/package.json`**: Replaced `inquirer` with `@inquirer/prompts`, removed outdated `@types/inquirer`
2. **`apps/publisher/src/services/kdp.ts`**: Changed `import inquirer from "inquirer"` → `import { input } from "@inquirer/prompts"`, and updated the two 2FA prompt calls to use the new API

The commit `1b19de5` is ready on branch `kaylee/pr-285-fix-1767909179588`.

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
Inquirer v13 is a breaking change - it removed the legacy `inquirer.prompt()` API and now requires `@inquirer/prompts` package with individual prompt functions like `input()`.

### Fix
Edited 2 files:
1. **`apps/publisher/package.json`**: Replaced `inquirer` with `@inquirer/prompts`, removed outdated `@types/inquirer`
2. **`apps/publisher/src/services/kdp.ts`**: Changed `import inquirer from "inquirer"` → `import { input } from "@inquirer/prompts"`, and updated the two 2FA prompt calls to use the new API

The commit `1b19de5` is ready on branch `kaylee/pr-285-fix-1767909179588`.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #285 in misty-step/brainrot*
