### PR TITLE
🔧 Lock file mismatch - package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,8 +369,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       marked:
-        specifier: ^16.2.1
-        version: 16.2.1
+        specifier: ^17.0.0
+        version: 17.0.1
       p-limit:
         specifier: ^7.1.1
         version: 7.1.1
@@ -7332,8 +7332,8 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
-  /marked@16.2.1:
-    resolution: {integrity: sha512-r3UrXED9lMlHF97jJByry90cwrZBBvZmjG1L68oYfuPMW+uDTnuMbyJDymCWwbTE+f+3LhpNDKfpR3a3saFyjA==}
+  /marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
     engines: {node: '>= 20'}
     hasBin: true
     dev: false


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Lock file mismatch - package.json had `marked@^17.0.0` but pnpm-lock.yaml still referenced `16.2.1`, causing CI to fail with "frozen-lockfile" check.

### What I fixed
Regenerated `pnpm-lock.yaml` by running `pnpm install --no-frozen-lockfile`, which updated the marked dependency from 16.2.1 to 17.0.0 in the lock file.

**Note**: The `marked` package is actually unused in this codebase (the code uses `remove-markdown` instead). Someone might want to remove it as a dependency later to clean things up, but that's a separate concern. The immediate CI fix is done.

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
Lock file mismatch - package.json had `marked@^17.0.0` but pnpm-lock.yaml still referenced `16.2.1`, causing CI to fail with "frozen-lockfile" check.

### Fix
Regenerated `pnpm-lock.yaml` by running `pnpm install --no-frozen-lockfile`, which updated the marked dependency from 16.2.1 to 17.0.0 in the lock file.

**Note**: The `marked` package is actually unused in this codebase (the code uses `remove-markdown` instead). Someone might want to remove it as a dependency later to clean things up, but that's a separate concern. The immediate CI fix is done.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #264 in misty-step/brainrot*
