### PR TITLE
🛠️ `@trivago/prettier-plugin-sort-imports` v6

### DIFF
--- a/apps/web/.prettierrc.mjs
+++ b/apps/web/.prettierrc.mjs
@@ -7,10 +7,7 @@
  * 3. Provide clear, readable code that follows best practices
  */
 
-// Explicitly require the plugin in CJS format
-const sortImports = require('@trivago/prettier-plugin-sort-imports');
-
-module.exports = {
+export default {
   // Basic formatting
   printWidth: 100, // Line length where Prettier will try to wrap
   tabWidth: 2, // Number of spaces per indentation level
@@ -63,6 +60,6 @@ module.exports = {
     },
   ],
 
-  // Explicitly define the plugins to use
-  plugins: [sortImports],
+  // Explicitly define the plugins to use (using string format for ESM compatibility)
+  plugins: ['@trivago/prettier-plugin-sort-imports'],
 };


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
`@trivago/prettier-plugin-sort-imports` v6.0.0 is ESM-only, but the prettier config was using CommonJS format (`.prettierrc.cjs` with `require()` and `module.exports`).

### What I fixed
Converted `.prettierrc.cjs` → `.prettierrc.mjs` with ESM syntax:
- Removed `const sortImports = require('@trivago/prettier-plugin-sort-imports')`
- Changed `module.exports = {...}` to `export default {...}`
- Changed `plugins: [sortImports]` to `plugins: ['@trivago/prettier-plugin-sort-imports']` (string format)

**Commit:** `4bf5541` on branch `kaylee/pr-257-fix-1767909538035`

### The details
<details>
<summary>Full diagnosis</summary>

### Root Cause
`@trivago/prettier-plugin-sort-imports` v6.0.0 is ESM-only, but the prettier config was using CommonJS format (`.prettierrc.cjs` with `require()` and `module.exports`).

### Fix
Converted `.prettierrc.cjs` → `.prettierrc.mjs` with ESM syntax:
- Removed `const sortImports = require('@trivago/prettier-plugin-sort-imports')`
- Changed `module.exports = {...}` to `export default {...}`
- Changed `plugins: [sortImports]` to `plugins: ['@trivago/prettier-plugin-sort-imports']` (string format)

**Commit:** `4bf5541` on branch `kaylee/pr-257-fix-1767909538035`
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #257 in misty-step/brainrot*
