### PR TITLE
fix: Two issues: (1) `auto-merge-security

### DIFF
--- a/.github/workflows/auto-merge-security.yml
+++ b/.github/workflows/auto-merge-security.yml
@@ -89,7 +89,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "Test - Node 22"
+          checkName: "Test"
           ref: ${{ github.event.pull_request.head.sha }}
           timeoutSeconds: 600
           intervalSeconds: 30

--- a/apps/web/utils/logger.ts
+++ b/apps/web/utils/logger.ts
@@ -18,9 +18,6 @@ const createClientLogger = () => {
 const createServerLogger = () => {
   return pino({
     level: process.env.LOG_LEVEL || 'info',
-    browser: {
-      asObject: true,
-    },
   });
 };
 


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Two issues: (1) `auto-merge-security.yml` waits for check "Test - Node 22" that doesn't exist (actual job is named "Test"), causing 10-minute timeout; (2) `logger.ts` uses `browser` option removed in pino v10.

### What I fixed
1. **`.github/workflows/auto-merge-security.yml`**: Changed `checkName: "Test - Node 22"` to `checkName: "Test"` to match actual CI job name in `ci.yml`
2. **`apps/web/utils/logger.ts`**: Removed the deprecated `browser: { asObject: true }` option from pino config (this option was removed in pino v10.0.0)

Commit: `b23af9b` - "fix: correct workflow check name and remove deprecated pino option"

### The details
<details>
<summary>Full diagnosis</summary>

### Root Cause
Two issues: (1) `auto-merge-security.yml` waits for check "Test - Node 22" that doesn't exist (actual job is named "Test"), causing 10-minute timeout; (2) `logger.ts` uses `browser` option removed in pino v10.

### Fix
1. **`.github/workflows/auto-merge-security.yml`**: Changed `checkName: "Test - Node 22"` to `checkName: "Test"` to match actual CI job name in `ci.yml`
2. **`apps/web/utils/logger.ts`**: Removed the deprecated `browser: { asObject: true }` option from pino config (this option was removed in pino v10.0.0)

Commit: `b23af9b` - "fix: correct workflow check name and remove deprecated pino option"
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #217 in misty-step/brainrot*
