### PR TITLE
🛠️ Dependabot updated `pino` version in `package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^5.20.0
         version: 5.20.0
       pino:
-        specifier: ^9.9.4
-        version: 9.9.4
+        specifier: ^10.1.0
+        version: 10.1.0
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.1
@@ -3246,6 +3246,10 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
+  /@pinojs/redact@0.4.0:
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -6241,11 +6245,6 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
-    dev: false
-
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: false
@@ -7866,12 +7865,12 @@ packages:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
     dev: false
 
-  /pino@9.9.4:
-    resolution: {integrity: sha512-d1XorUQ7sSKqVcYdXuEYs2h1LKxejSorMEJ76XoZ0pPDf8VzJMe7GlPXpMBZeQ9gE4ZPIp5uGD+5Nw7scxiigg==}
+  /pino@10.1.0:
+    resolution: {integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==}
     hasBin: true
     dependencies:
+      '@pinojs/redact': 0.4.0
       atomic-sleep: 1.0.0
-      fast-redact: 3.5.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
       pino-std-serializers: 7.0.0


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Dependabot updated `pino` version in `package.json` but didn't regenerate `pnpm-lock.yaml`, causing CI to fail with `ERR_PNPM_OUTDATED_LOCKFILE` due to the frozen-lockfile setting in CI.

### What I fixed
Regenerated `pnpm-lock.yaml` by running `pnpm install --no-frozen-lockfile`. This updated the lockfile to match the new `pino@^10.1.0` specifier in `apps/web/package.json`.

The fix is committed to branch `kaylee/pr-215-fix-1767909804856` and ready to be pushed. Both lint and typecheck pass now. ✅

### The details
<details>
<summary>Full diagnosis</summary>

### Root Cause
Dependabot updated `pino` version in `package.json` but didn't regenerate `pnpm-lock.yaml`, causing CI to fail with `ERR_PNPM_OUTDATED_LOCKFILE` due to the frozen-lockfile setting in CI.

### Fix
Regenerated `pnpm-lock.yaml` by running `pnpm install --no-frozen-lockfile`. This updated the lockfile to match the new `pino@^10.1.0` specifier in `apps/web/package.json`.

The fix is committed to branch `kaylee/pr-215-fix-1767909804856` and ready to be pushed. Both lint and typecheck pass now. ✅
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #215 in misty-step/brainrot*
