### PR TITLE
🛠️ Prettier formatting violations and unescaped apost

### DIFF
--- a/apps/web/app/fonts.ts
+++ b/apps/web/app/fonts.ts
@@ -1,4 +1,4 @@
-import { Space_Grotesk, Crimson_Pro } from 'next/font/google';
+import { Crimson_Pro, Space_Grotesk } from 'next/font/google';
 
 export const display = Space_Grotesk({
   subsets: ['latin'],

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 import FooterV3 from '@/components/FooterV3';
 import Header from '@/components/header';
 
-import { display, body } from './fonts';
+import { body, display } from './fonts';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -14,11 +14,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html
-      lang="en"
-      className={`${display.variable} ${body.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" className={`${display.variable} ${body.variable}`} suppressHydrationWarning>
       <body>
         {/* header */}
         <Header />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -39,7 +39,7 @@ export default function HomePage() {
             <span className="mx-8">romeo and juliet</span>
             <span className="mx-8">hamlet</span>
             <span className="mx-8">macbeth</span>
-            <span className="mx-8">a midsummer night's dream</span>
+            <span className="mx-8">a midsummer night&apos;s dream</span>
           </div>
           <div className="flex shrink-0" aria-hidden="true">
             <span className="mx-8">the bible</span>
@@ -54,7 +54,7 @@ export default function HomePage() {
             <span className="mx-8">romeo and juliet</span>
             <span className="mx-8">hamlet</span>
             <span className="mx-8">macbeth</span>
-            <span className="mx-8">a midsummer night's dream</span>
+            <span className="mx-8">a midsummer night&apos;s dream</span>
           </div>
         </div>
       </div>

--- a/apps/web/app/reading-room/[slug]/page.tsx
+++ b/apps/web/app/reading-room/[slug]/page.tsx
@@ -37,8 +37,10 @@ export default function ReadingRoom() {
   const { rawText, isTextLoading } = useTextLoader(slug, chapterData?.text);
 
   // Set up audio player
-  const [{ isPlaying, isAudioLoading, currentTime, totalTime, error }, { togglePlayPause, formatTime }] =
-    useAudioPlayer(waveformRef, chapterData?.audioSrc, updateTimestamp);
+  const [
+    { isPlaying, isAudioLoading, currentTime, totalTime, error },
+    { togglePlayPause, formatTime },
+  ] = useAudioPlayer(waveformRef, chapterData?.audioSrc, updateTimestamp);
 
   // Set up share modal
   const [

--- a/apps/web/components/reading-room/AudioPlayer.tsx
+++ b/apps/web/components/reading-room/AudioPlayer.tsx
@@ -86,11 +86,7 @@ export default function AudioPlayer(props: AudioPlayerProps) {
       )}
 
       {/* Aria-live region for audio state announcements (screen reader only) */}
-      <div
-        role="status"
-        aria-live="polite"
-        className="sr-only"
-      >
+      <div role="status" aria-live="polite" className="sr-only">
         {isPlaying ? 'audio playing' : 'audio paused'}
       </div>
 

--- a/apps/web/components/reading-room/ChapterHeader.tsx
+++ b/apps/web/components/reading-room/ChapterHeader.tsx
@@ -35,44 +35,46 @@ export default function ChapterHeader(props: ChapterHeaderProps) {
       <div className="px-4 py-3 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-display font-bold">{translation.title}</h1>
-          <p className="text-sm font-body text-lavender">{translation.chapters[chapterIndex].title}</p>
+          <p className="text-sm font-body text-lavender">
+            {translation.chapters[chapterIndex].title}
+          </p>
           <p className="text-xs font-body text-white/60 mt-1">
             Chapter {chapterIndex + 1} of {totalChapters}
           </p>
         </div>
-      <div className="flex items-center gap-2">
-        {translation.purchaseUrl && (
-          <Link
-            href={translation.purchaseUrl}
-            className="btn btn-primary"
-            target="_blank"
-            rel="noopener noreferrer"
+        <div className="flex items-center gap-2">
+          {translation.purchaseUrl && (
+            <Link
+              href={translation.purchaseUrl}
+              className="btn btn-primary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              buy now
+            </Link>
+          )}
+          <button
+            onClick={onPrevChapter}
+            className={`btn btn-secondary ${
+              chapterIndex === 0 ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
+            disabled={chapterIndex === 0}
           >
-            buy now
-          </Link>
-        )}
-        <button
-          onClick={onPrevChapter}
-          className={`btn btn-secondary ${
-            chapterIndex === 0 ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
-          disabled={chapterIndex === 0}
-        >
-          ← prev
-        </button>
-        <button
-          onClick={onNextChapter}
-          className={`btn btn-secondary ${
-            chapterIndex === totalChapters - 1 ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
-          disabled={chapterIndex === totalChapters - 1}
-        >
-          next →
-        </button>
-        <button onClick={onOpenShareModal} className="btn btn-secondary">
-          share
-        </button>
-      </div>
+            ← prev
+          </button>
+          <button
+            onClick={onNextChapter}
+            className={`btn btn-secondary ${
+              chapterIndex === totalChapters - 1 ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
+            disabled={chapterIndex === totalChapters - 1}
+          >
+            next →
+          </button>
+          <button onClick={onOpenShareModal} className="btn btn-secondary">
+            share
+          </button>
+        </div>
       </div>
 
       {/* Reading progress bar */}

--- a/apps/web/components/reading-room/ChapterSidebar.tsx
+++ b/apps/web/components/reading-room/ChapterSidebar.tsx
@@ -36,12 +36,7 @@ export default function ChapterSidebar({
         className="lg:hidden fixed top-4 left-4 z-40 p-2 bg-black/80 rounded border border-white/20 hover:bg-black/90"
         aria-label={isOpen ? 'Close chapter menu' : 'Open chapter menu'}
       >
-        <svg
-          className="w-6 h-6 text-white"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
+        <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           {isOpen ? (
             <path
               strokeLinecap="round"
@@ -68,27 +63,31 @@ export default function ChapterSidebar({
           ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
         `}
       >
-      <h2 className="text-lg font-display font-bold mb-4 text-peachy">chapters</h2>
-      <nav className="flex flex-col space-y-2">
-        {chaptersArray.map((cNum) => {
-          const isActive = cNum === chapterIndex;
-          return (
-            <button
-              key={cNum}
-              onClick={() => onChapterClick(cNum)}
-              className={`px-3 py-2 rounded border text-sm font-body text-left ${
-                isActive
-                  ? 'bg-peachy text-midnight border-peachy'
-                  : 'bg-black/30 text-white/80 border-white/20 hover:bg-black/50'
-              }`}
-            >
-              {isActive && <span className="mr-2" aria-hidden="true">▶</span>}
-              {translation.chapters[cNum].title}
-            </button>
-          );
-        })}
-      </nav>
-    </aside>
+        <h2 className="text-lg font-display font-bold mb-4 text-peachy">chapters</h2>
+        <nav className="flex flex-col space-y-2">
+          {chaptersArray.map((cNum) => {
+            const isActive = cNum === chapterIndex;
+            return (
+              <button
+                key={cNum}
+                onClick={() => onChapterClick(cNum)}
+                className={`px-3 py-2 rounded border text-sm font-body text-left ${
+                  isActive
+                    ? 'bg-peachy text-midnight border-peachy'
+                    : 'bg-black/30 text-white/80 border-white/20 hover:bg-black/50'
+                }`}
+              >
+                {isActive && (
+                  <span className="mr-2" aria-hidden="true">
+                    ▶
+                  </span>
+                )}
+                {translation.chapters[cNum].title}
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
     </>
   );
 }

--- a/apps/web/components/reading-room/ShareModal.tsx
+++ b/apps/web/components/reading-room/ShareModal.tsx
@@ -133,7 +133,9 @@ export default function ShareModal(props: ShareModalProps) {
               />
               <span>include chapter</span>
             </label>
-            <p className="text-xs font-body text-white/60 ml-6 mt-1">link opens to current chapter</p>
+            <p className="text-xs font-body text-white/60 ml-6 mt-1">
+              link opens to current chapter
+            </p>
           </div>
           <div>
             <label className="flex items-center gap-2 font-body" htmlFor="include-timestamp">
@@ -145,7 +147,9 @@ export default function ShareModal(props: ShareModalProps) {
               />
               <span>include timestamp</span>
             </label>
-            <p className="text-xs font-body text-white/60 ml-6 mt-1">link starts audio at current position</p>
+            <p className="text-xs font-body text-white/60 ml-6 mt-1">
+              link starts audio at current position
+            </p>
           </div>
         </div>
         <div className="space-y-2">

--- a/apps/web/components/reading-room/TextContent.tsx
+++ b/apps/web/components/reading-room/TextContent.tsx
@@ -16,12 +16,12 @@ function SkeletonLoader() {
     'w-full',
     'w-10/12',
     'w-8/12', // Short line (paragraph break)
-    '',       // Empty line
+    '', // Empty line
     'w-full',
     'w-full',
     'w-9/12',
     'w-7/12', // Short line (paragraph break)
-    '',       // Empty line
+    '', // Empty line
     'w-full',
   ];
 


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Prettier formatting violations and unescaped apostrophe (`'`) in JSX causing `prettier/prettier` and `react/no-unescaped-entities` lint errors.

### What I fixed
1. Ran `prettier --write` on 9 files in apps/web to fix formatting (fonts.ts, layout.tsx, page.tsx, reading-room/[slug]/page.tsx, AudioPlayer.tsx, ChapterHeader.tsx, ChapterSidebar.tsx, ShareModal.tsx, TextContent.tsx)
2. Replaced `'` with `&apos;` in "a midsummer night's dream" (2 occurrences in page.tsx) to fix the JSX escape error

Commit pushed to `kaylee/pr-295-fix-1767910651144`.

### The details
<details>
<summary>Full diagnosis</summary>

All errors are fixed. Only warnings remain (complexity warnings in the download API), but those don't cause CI to fail.

### Root Cause
Prettier formatting violations and unescaped apostrophe (`'`) in JSX causing `prettier/prettier` and `react/no-unescaped-entities` lint errors.

### Fix
1. Ran `prettier --write` on 9 files in apps/web to fix formatting (fonts.ts, layout.tsx, page.tsx, reading-room/[slug]/page.tsx, AudioPlayer.tsx, ChapterHeader.tsx, ChapterSidebar.tsx, ShareModal.tsx, TextContent.tsx)
2. Replaced `'` with `&apos;` in "a midsummer night's dream" (2 occurrences in page.tsx) to fix the JSX escape error

Commit pushed to `kaylee/pr-295-fix-1767910651144`.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #295 in misty-step/brainrot*
